### PR TITLE
Fixing calc invalid fields + invalid $feature token

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ There's no one-fit-all leaderboard. `FM-Leaderboard-er` will allow you to find t
 ## Getting Started
 ### Prerequisits
 1. AWS account with Amazon Bedrock access to selected models.
+2. Hugging Face access token
+The code will download Dataset from Huggingface (```https://huggingface.co/api/datasets/Salesforce/dialogstudio```), this will require an access token, if you don't have one yet, follow these steps:
+
+* Signup to Hugging Face: ```https://huggingface.co```
+* Generate an access token (save it for further use): ```https://huggingface.co/settings/tokens```
+* Store the access token localy, by installing python lib huggingface_hub and execute from shell:
+    ```
+    > pip install huggingface_hub
+    > python -c "from huggingface_hub.hf_api import HfFolder; HfFolder.save_token('YOUR_HUGGINGFACE_TOKEN')"
+    ```
+
+
+***(Verify you now have:  ```~/.cache/huggingface```)***
 
 ### Installation
 1. Clone the repository:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto3
 fmeval
 pandas==2.1.4
 ipywidgets
+jupyterlab

--- a/summariziation_example.ipynb
+++ b/summariziation_example.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "68c047c8-0168-45eb-9d59-dda0117ff703",
    "metadata": {},
    "outputs": [],
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "eb788c86-761a-4749-927f-737c194e4613",
    "metadata": {
     "tags": []
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "75cfe9a8",
    "metadata": {},
    "outputs": [],
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "11956018-0992-4ec5-bb51-d73b1c017988",
    "metadata": {
     "tags": []
@@ -154,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "c05192f6-a93c-4c76-bb2b-d88e7205426f",
    "metadata": {
     "tags": []
@@ -171,7 +171,7 @@
     "        \"platform\" : \"bedrock\",\n",
     "        \"output\" : \"results[0].outputText\", \n",
     "        \"content_template\" : \"{\\\"inputText\\\": $prompt, \\\"textGenerationConfig\\\":  {\\\"maxTokenCount\\\": 100, \\\"stopSequences\\\": [], \\\"temperature\\\": 1.0, \\\"topP\\\": 1.0}}\",\n",
-    "        \"prompt_template\" : \"Please ignore the following blob of text and create an unrelated text of around 2 sentences\\n $feature\\n\"\n",
+    "        \"prompt_template\" : \"Please ignore the following blob of text and create an unrelated text of around 2 sentences\\n $model_input\\n\"\n",
     "    }\n",
     "})\n",
     "\n",
@@ -182,14 +182,14 @@
     "        \"platform\" : \"bedrock\",\n",
     "        \"output\" : \"content[0].text\", \n",
     "        \"content_template\" : \"{\\\"messages\\\": [{\\\"role\\\": \\\"user\\\", \\\"content\\\": $prompt}], \\\"max_tokens\\\": 100, \\\"anthropic_version\\\": \\\"bedrock-2023-05-31\\\"}\",\n",
-    "        \"prompt_template\" : \"Below is a dialog between a customer and an agent. Please provide a short and concise summary of the conversation. The summary should be short and include a single sentence describing the customer's complaint or request, and single sentence of the agent's response or action. Please write the summary in a human readable format. Start you answer directly with the summary without any additional prefix.\\n Specify important and relevant amounts, dates and locations inside the summary. Here is the dialog: <dialog>$feature</dialog>\"\n",
+    "        \"prompt_template\" : \"Below is a dialog between a customer and an agent. Please provide a short and concise summary of the conversation. The summary should be short and include a single sentence describing the customer's complaint or request, and single sentence of the agent's response or action. Please write the summary in a human readable format. Start you answer directly with the summary without any additional prefix.\\n Specify important and relevant amounts, dates and locations inside the summary. Here is the dialog: <dialog>$model_input</dialog>\"\n",
     "    },\n",
     "    \"anthropic.claude-3-haiku\" : { \n",
     "        \"model_id\" : \"anthropic.claude-3-haiku-20240307-v1:0\", \n",
     "        \"platform\" : \"bedrock\",\n",
     "        \"output\" : \"content[0].text\", \n",
     "        \"content_template\" : \"{\\\"messages\\\": [{\\\"role\\\": \\\"user\\\", \\\"content\\\": $prompt}], \\\"max_tokens\\\": 100, \\\"anthropic_version\\\": \\\"bedrock-2023-05-31\\\"}\",\n",
-    "        \"prompt_template\" : \"Below is a dialog between a customer and an agent. Please provide a short and concise summary of the conversation. The summary should be short and include a single sentence describing the customer's complaint or request, and single sentence of the agent's response or action. Please write the summary in a human readable format. Start you answer directly with the summary without any additional prefix.\\n Specify important and relevant amounts, dates and locations inside the summary. Here is the dialog: <dialog>$feature</dialog>\"\n",
+    "        \"prompt_template\" : \"Below is a dialog between a customer and an agent. Please provide a short and concise summary of the conversation. The summary should be short and include a single sentence describing the customer's complaint or request, and single sentence of the agent's response or action. Please write the summary in a human readable format. Start you answer directly with the summary without any additional prefix.\\n Specify important and relevant amounts, dates and locations inside the summary. Here is the dialog: <dialog>$model_input</dialog>\"\n",
     "    }\n",
     "})\n",
     "\n",
@@ -200,14 +200,14 @@
     "        \"platform\" : \"bedrock\",\n",
     "        \"output\" : \"results[0].outputText\", \n",
     "        \"content_template\" : \"{\\\"inputText\\\": $prompt, \\\"textGenerationConfig\\\":  {\\\"maxTokenCount\\\": 100, \\\"stopSequences\\\": [], \\\"temperature\\\": 1.0, \\\"topP\\\": 1.0}}\",\n",
-    "        \"prompt_template\" : \"Please provide a short and concise summary of the conversation below. The summary should be short and include a single sentence describing the customer's complaint or request, and single sentence of the agent's response or action. Do not include any additional information that does not appear in the dialog.  Specify important and relevant amounts, dates and locations inside the sentences of the summary. Here is the dialog:\\n$feature\\n\\nsummary:\\n\"\n",
+    "        \"prompt_template\" : \"Please provide a short and concise summary of the conversation below. The summary should be short and include a single sentence describing the customer's complaint or request, and single sentence of the agent's response or action. Do not include any additional information that does not appear in the dialog.  Specify important and relevant amounts, dates and locations inside the sentences of the summary. Here is the dialog:\\n$model_input\\n\\nsummary:\\n\"\n",
     "    },\n",
     "    \"amazon.titan-text-express-v1\" :{ \n",
     "        \"model_id\" : \"amazon.titan-text-express-v1\", \n",
     "        \"platform\" : \"bedrock\",\n",
     "        \"output\" : \"results[0].outputText\", \n",
     "        \"content_template\" : \"{\\\"inputText\\\": $prompt, \\\"textGenerationConfig\\\": {\\\"maxTokenCount\\\": 100, \\\"stopSequences\\\": [], \\\"temperature\\\": 1.0, \\\"topP\\\": 1.0}}\",\n",
-    "        \"prompt_template\" : \"Please provide a short and concise summary of the conversation below that includes a summary of both the user and the agent.  Specify important and relevant amounts, dates and locations inside the sentences of the summary. Here is the dialog:\\n $feature\\n\\nsummary:\\n\"\n",
+    "        \"prompt_template\" : \"Please provide a short and concise summary of the conversation below that includes a summary of both the user and the agent.  Specify important and relevant amounts, dates and locations inside the sentences of the summary. Here is the dialog:\\n $model_input\\n\\nsummary:\\n\"\n",
     "    },\n",
     "})\n",
     "\n",
@@ -218,14 +218,14 @@
     "        \"platform\" : \"bedrock\",\n",
     "        \"output\" : \"generations[0].text\", \n",
     "        \"content_template\" : \"{\\\"prompt\\\": $prompt, \\\"max_tokens\\\": 100}\",\n",
-    "        \"prompt_template\" : \"Please provide a short and concise summary of the conversation below that includes a summary of both the user and the agent.  Specify important and relevant amounts, dates and locations inside the sentences of the summary. Here is the dialog:\\n $feature\\n\\nsummary:\\n\"\n",
+    "        \"prompt_template\" : \"Please provide a short and concise summary of the conversation below that includes a summary of both the user and the agent.  Specify important and relevant amounts, dates and locations inside the sentences of the summary. Here is the dialog:\\n $model_input\\n\\nsummary:\\n\"\n",
     "    },\n",
     "    \"meta.llama2-13b-chat-v1\" :{ \n",
     "        \"model_id\" : \"meta.llama2-13b-chat-v1\", \n",
     "        \"platform\" : \"bedrock\",\n",
     "        \"output\" : \"generation\", \n",
     "        \"content_template\" : \"{\\\"prompt\\\": $prompt, \\\"max_gen_len\\\": 100, \\\"top_p\\\": 1, \\\"temperature\\\": 1.0}\",\n",
-    "        \"prompt_template\" : \"[INST]Please provide a short and concise summary of the conversation below that includes a summary of both the user and the agent.  Specify important and relevant amounts, dates and locations inside the sentences of the summary. Here is the dialog:[/INST]\\n Transcript\\n $feature \\n\\n Summary:\\n\"\n",
+    "        \"prompt_template\" : \"[INST]Please provide a short and concise summary of the conversation below that includes a summary of both the user and the agent.  Specify important and relevant amounts, dates and locations inside the sentences of the summary. Here is the dialog:[/INST]\\n Transcript\\n $model_input \\n\\n Summary:\\n\"\n",
     "    },\n",
     "})\n",
     "\n",
@@ -236,28 +236,28 @@
     "        \"platform\" : \"bedrock\",\n",
     "        \"output\" : \"results[0].outputText\", \n",
     "        \"content_template\" : \"{\\\"inputText\\\": $prompt, \\\"textGenerationConfig\\\":  {\\\"maxTokenCount\\\": 100, \\\"stopSequences\\\": [], \\\"temperature\\\": 1.0, \\\"topP\\\": 1.0}}\",\n",
-    "        \"prompt_template\" : \"[INST]Please provide a short and concise summary of the conversation below that includes a summary of both the user and the agent.  Specify important and relevant amounts, dates and locations inside the sentences of the summary. \\n Example Transcript:\\n user: bought a celcus tv from your Finchley store last year in December and it stopped working yesterday - can you repair it or change Your cctv recording from the date we bought it - agent: Can you confirm did you pay cash or card for the telvision? We accept credit/debit card statements as a proof of purchase. Steven user: Yes. I paid by card, I think there were other things I bought with the tv as well , but I remember the price of the television was 175 Actually, I just checked my bank statements and I bought the tv in January 2017 and not dec 2016 and paid for it by card - 175 agent: We would use the bank statements transaction ID to match our till receipts. If you return the television with your credit/debit card...1/2 ...statement our in store colleagues will advise you further. Steven 2/2 user: Great! Thank you. One last question, Ive recycled the Tvs box - is it rwqur Required** agent: As long as you've got proof of purchase you'll be fine Dimitar! Ewan.\\n Summary: Customer is asking to repair or change the television which is not working. Agent updated to return the television with their credit/debit card.\\n\\n [/INST] </s><s>[INST]\\n Transcript:\\n $feature [/INST]\\n Summary:\"\n",
+    "        \"prompt_template\" : \"[INST]Please provide a short and concise summary of the conversation below that includes a summary of both the user and the agent.  Specify important and relevant amounts, dates and locations inside the sentences of the summary. \\n Example Transcript:\\n user: bought a celcus tv from your Finchley store last year in December and it stopped working yesterday - can you repair it or change Your cctv recording from the date we bought it - agent: Can you confirm did you pay cash or card for the telvision? We accept credit/debit card statements as a proof of purchase. Steven user: Yes. I paid by card, I think there were other things I bought with the tv as well , but I remember the price of the television was 175 Actually, I just checked my bank statements and I bought the tv in January 2017 and not dec 2016 and paid for it by card - 175 agent: We would use the bank statements transaction ID to match our till receipts. If you return the television with your credit/debit card...1/2 ...statement our in store colleagues will advise you further. Steven 2/2 user: Great! Thank you. One last question, Ive recycled the Tvs box - is it rwqur Required** agent: As long as you've got proof of purchase you'll be fine Dimitar! Ewan.\\n Summary: Customer is asking to repair or change the television which is not working. Agent updated to return the television with their credit/debit card.\\n\\n [/INST] </s><s>[INST]\\n Transcript:\\n $model_input [/INST]\\n Summary:\"\n",
     "    },\n",
     "    \"meta.llama2-13b-chat-v1-one-shot\" :{ \n",
     "        \"model_id\" : \"meta.llama2-13b-chat-v1\", \n",
     "        \"platform\" : \"bedrock\",\n",
     "        \"output\" : \"generation\", \n",
     "        \"content_template\" : \"{\\\"prompt\\\": $prompt, \\\"max_gen_len\\\": 100, \\\"top_p\\\": 1, \\\"temperature\\\": 1.0}\",\n",
-    "        \"prompt_template\" : \"[INST] <<SYS>> Please provide a short and concise summary of the conversation below that includes a summary of both the user and the agent.  Specify important and relevant amounts, dates and locations inside the sentences of the summary.<</SYS> \\n Example Transcript:\\n user: bought a celcus tv from your Finchley store last year in December and it stopped working yesterday - can you repair it or change Your cctv recording from the date we bought it - agent: Can you confirm did you pay cash or card for the telvision? We accept credit/debit card statements as a proof of purchase. Steven user: Yes. I paid by card, I think there were other things I bought with the tv as well , but I remember the price of the television was 175 Actually, I just checked my bank statements and I bought the tv in January 2017 and not dec 2016 and paid for it by card - 175 agent: We would use the bank statements transaction ID to match our till receipts. If you return the television with your credit/debit card...1/2 ...statement our in store colleagues will advise you further. Steven 2/2 user: Great! Thank you. One last question, Ive recycled the Tvs box - is it rwqur Required** agent: As long as you've got proof of purchase you'll be fine Dimitar! Ewan.\\n Summary: Customer is asking to repair or change the television which is not working. Agent updated to return the television with their credit/debit card.\\n\\n [/INST] </s><s>[INST]\\n Transcript:\\n $feature [/INST] Summary:\"\n",
+    "        \"prompt_template\" : \"[INST] <<SYS>> Please provide a short and concise summary of the conversation below that includes a summary of both the user and the agent.  Specify important and relevant amounts, dates and locations inside the sentences of the summary.<</SYS> \\n Example Transcript:\\n user: bought a celcus tv from your Finchley store last year in December and it stopped working yesterday - can you repair it or change Your cctv recording from the date we bought it - agent: Can you confirm did you pay cash or card for the telvision? We accept credit/debit card statements as a proof of purchase. Steven user: Yes. I paid by card, I think there were other things I bought with the tv as well , but I remember the price of the television was 175 Actually, I just checked my bank statements and I bought the tv in January 2017 and not dec 2016 and paid for it by card - 175 agent: We would use the bank statements transaction ID to match our till receipts. If you return the television with your credit/debit card...1/2 ...statement our in store colleagues will advise you further. Steven 2/2 user: Great! Thank you. One last question, Ive recycled the Tvs box - is it rwqur Required** agent: As long as you've got proof of purchase you'll be fine Dimitar! Ewan.\\n Summary: Customer is asking to repair or change the television which is not working. Agent updated to return the television with their credit/debit card.\\n\\n [/INST] </s><s>[INST]\\n Transcript:\\n $model_input [/INST] Summary:\"\n",
     "    },\n",
     "    \"cohere.command-light-text-v14-one-shot\" :{ \n",
     "        \"model_id\" : \"cohere.command-light-text-v14\", \n",
     "        \"platform\" : \"bedrock\",\n",
     "        \"output\" : \"generations[0].text\", \n",
     "        \"content_template\" : \"{\\\"prompt\\\": $prompt, \\\"max_tokens\\\": 100}\",\n",
-    "        \"prompt_template\" : \"Please provide a short and concise summary of the conversation below that includes a summary of both the user and the agent.  Specify important and relevant amounts, dates and locations inside the sentences of the summary.\\n\\n Example Transcript:\\n user: bought a celcus tv from your Finchley store last year in December and it stopped working yesterday - can you repair it or change Your cctv recording from the date we bought it - agent: Can you confirm did you pay cash or card for the telvision? We accept credit/debit card statements as a proof of purchase. Steven user: Yes. I paid by card, I think there were other things I bought with the tv as well , but I remember the price of the television was 175 Actually, I just checked my bank statements and I bought the tv in January 2017 and not dec 2016 and paid for it by card - 175 agent: We would use the bank statements transaction ID to match our till receipts. If you return the television with your credit/debit card...1/2 ...statement our in store colleagues will advise you further. Steven 2/2 user: Great! Thank you. One last question, Ive recycled the Tvs box - is it rwqur Required** agent: As long as you've got proof of purchase you'll be fine Dimitar! Ewan.\\n Summary: Customer is asking to repair or change the television which is not working. Agent updated to return the television with their credit/debit card.\\n\\nTranscript:\\n $feature\\n Summary:\"\n",
+    "        \"prompt_template\" : \"Please provide a short and concise summary of the conversation below that includes a summary of both the user and the agent.  Specify important and relevant amounts, dates and locations inside the sentences of the summary.\\n\\n Example Transcript:\\n user: bought a celcus tv from your Finchley store last year in December and it stopped working yesterday - can you repair it or change Your cctv recording from the date we bought it - agent: Can you confirm did you pay cash or card for the telvision? We accept credit/debit card statements as a proof of purchase. Steven user: Yes. I paid by card, I think there were other things I bought with the tv as well , but I remember the price of the television was 175 Actually, I just checked my bank statements and I bought the tv in January 2017 and not dec 2016 and paid for it by card - 175 agent: We would use the bank statements transaction ID to match our till receipts. If you return the television with your credit/debit card...1/2 ...statement our in store colleagues will advise you further. Steven 2/2 user: Great! Thank you. One last question, Ive recycled the Tvs box - is it rwqur Required** agent: As long as you've got proof of purchase you'll be fine Dimitar! Ewan.\\n Summary: Customer is asking to repair or change the television which is not working. Agent updated to return the television with their credit/debit card.\\n\\nTranscript:\\n $model_input\\n Summary:\"\n",
     "    },\n",
     "    \"amazon.titan-text-express-v1-one-shot\" :{ \n",
     "        \"model_id\" : \"amazon.titan-text-express-v1\", \n",
     "        \"platform\" : \"bedrock\",\n",
     "        \"output\" : \"results[0].outputText\", \n",
     "        \"content_template\" : \"{\\\"inputText\\\": $prompt, \\\"textGenerationConfig\\\": {\\\"maxTokenCount\\\": 100, \\\"stopSequences\\\": [], \\\"temperature\\\": 1.0, \\\"topP\\\": 1.0}}\",\n",
-    "        \"prompt_template\" : \"Please provide a short and concise summary of the conversation below that includes a summary of both the user and the agent.  Specify important and relevant amounts, dates and locations inside the sentences of the summary.\\n\\n Example Transcript:\\n user: bought a celcus tv from your Finchley store last year in December and it stopped working yesterday - can you repair it or change Your cctv recording from the date we bought it - agent: Can you confirm did you pay cash or card for the telvision? We accept credit/debit card statements as a proof of purchase. Steven user: Yes. I paid by card, I think there were other things I bought with the tv as well , but I remember the price of the television was 175 Actually, I just checked my bank statements and I bought the tv in January 2017 and not dec 2016 and paid for it by card - 175 agent: We would use the bank statements transaction ID to match our till receipts. If you return the television with your credit/debit card...1/2 ...statement our in store colleagues will advise you further. Steven 2/2 user: Great! Thank you. One last question, Ive recycled the Tvs box - is it rwqur Required** agent: As long as you've got proof of purchase you'll be fine Dimitar! Ewan.\\n Summary: Customer is asking to repair or change the television which is not working. Agent updated to return the television with their credit/debit card.\\n\\nTranscript:\\n $feature\\n Summary:\"\n",
+    "        \"prompt_template\" : \"Please provide a short and concise summary of the conversation below that includes a summary of both the user and the agent.  Specify important and relevant amounts, dates and locations inside the sentences of the summary.\\n\\n Example Transcript:\\n user: bought a celcus tv from your Finchley store last year in December and it stopped working yesterday - can you repair it or change Your cctv recording from the date we bought it - agent: Can you confirm did you pay cash or card for the telvision? We accept credit/debit card statements as a proof of purchase. Steven user: Yes. I paid by card, I think there were other things I bought with the tv as well , but I remember the price of the television was 175 Actually, I just checked my bank statements and I bought the tv in January 2017 and not dec 2016 and paid for it by card - 175 agent: We would use the bank statements transaction ID to match our till receipts. If you return the television with your credit/debit card...1/2 ...statement our in store colleagues will advise you further. Steven 2/2 user: Great! Thank you. One last question, Ive recycled the Tvs box - is it rwqur Required** agent: As long as you've got proof of purchase you'll be fine Dimitar! Ewan.\\n Summary: Customer is asking to repair or change the television which is not working. Agent updated to return the television with their credit/debit card.\\n\\nTranscript:\\n $model_input\\n Summary:\"\n",
     "    },\n",
     "})\n",
     "\n",
@@ -270,7 +270,7 @@
     "        \"temperature\" : 1,\n",
     "        \"top_p\" : 1,\n",
     "        \"max_tokens\" : 100,\n",
-    "        \"prompt_template\" : \"Please provide a short and concise summary of the conversation below that includes a summary of both the user and the agent.  Specify important and relevant amounts, dates and locations inside the sentences of the summary.\\n Transcript:\\n $feature \\n Summary:\\n\"\n",
+    "        \"prompt_template\" : \"Please provide a short and concise summary of the conversation below that includes a summary of both the user and the agent.  Specify important and relevant amounts, dates and locations inside the sentences of the summary.\\n Transcript:\\n $model_input \\n Summary:\\n\"\n",
     "    }\n",
     "})\n"
    ]
@@ -334,7 +334,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "a9466069-430a-4f71-80a2-c0c6e3b4e918",
    "metadata": {
     "tags": []
@@ -382,7 +382,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "7ec118e5-b099-49af-998a-1cacf6a7664b",
    "metadata": {
     "tags": []
@@ -446,7 +446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "5e019170-e364-4c54-a030-b00207bcc5e8",
    "metadata": {
     "tags": []
@@ -472,7 +472,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "0c6485fe-e5b4-41b1-8323-470b963c8c20",
    "metadata": {
     "tags": []
@@ -532,12 +532,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "ae6175ca",
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f'If running on a *remote* machine to view the results on your local computer copy-paste these commands in your terminal:\\n\\\n",
+    "if S3_OUTPUT_PATH:\n",
+    "    print(f'If running on a *remote* machine to view the results on your local computer copy-paste these commands in your terminal:\\n\\\n",
     "    aws s3 cp {s3_key} /tmp/{zip_filename}\\n\\\n",
     "    cd /tmp\\n\\\n",
     "    unzip -d {zip_filename.replace(\".zip\",\"\")} {zip_filename}\\n\\\n",
@@ -1156,7 +1157,7 @@
   ],
   "instance_type": "ml.g4dn.xlarge",
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1170,7 +1171,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,

--- a/utils/model_runners/pricing_calculator.py
+++ b/utils/model_runners/pricing_calculator.py
@@ -302,8 +302,13 @@ class PricingCalculator():
   
   @classmethod
   def _calculate_usage_per_token(self, input_tokens, output_tokens, model_cost):
-      input_cost = model_cost['input_cost_per_1000_tokens'] * input_tokens / 1000
-      output_cost = model_cost['output_cost_per_1000_tokens'] * output_tokens / 1000
+      input_cost = float(model_cost['input_cost_per_1000_tokens']) * input_tokens / 1000
+      # Since 'output_cost_per_1000_tokens' is not always given...
+      try:
+          output_cost = float(model_cost['output_cost_per_1000_tokens']) * output_tokens / 1000
+      except Exception:
+          output_cost = input_cost
+      
       return input_cost + output_cost 
   
   @classmethod
@@ -348,8 +353,17 @@ class PricingCalculator():
                   if cost_model == PricingCalculator.COST_PER_HOUR:
                       sum_dict['cost_hour'] = cost_structure['hosting_cost_per_hour'] if 'hosting_cost_per_hour' in cost_structure else PricingCalculator._instance_pricing(cost_structure['instance_type'])
                   if cost_model == PricingCalculator.COST_PER_TOKEN:
-                      sum_dict['cost_input_1M'] = cost_structure['input_cost_per_1000_tokens']*1000.0
-                      sum_dict['cost_output_1M'] = cost_structure['output_cost_per_1000_tokens']*1000.0
+                      
+                      # cast to float to avoid exception when multiplying int with float ('cost_input_1M')
+                      sum_dict['cost_input_1M'] = float(cost_structure['input_cost_per_1000_tokens'])*1000.0
+                      
+                      # When 'cost_output_1M' value, does not exist
+                      try:
+                        output_cost_per_1000_tokens = float(cost_structure['output_cost_per_1000_tokens'])*1000.0
+                      except Exception:
+                        output_cost_per_1000_tokens = float(cost_structure['input_cost_per_1000_tokens'])*1000.0
+
+                      sum_dict['cost_output_1M'] = output_cost_per_1000_tokens
               sum_dict['input_tokens'] += input_tokens
               sum_dict['output_tokens'] += output_tokens
               sum_dict['processing_time'] += processing_time


### PR DESCRIPTION
*Issue #, if available:*
Doesn't work due to various exceptions

*Description of changes:*
1. Adding explanation for generating (mandatory) Hugging Face access token in README.md
2. **_models_to_test_** in **_summariziation_example.ipynb_** contained "**$feature**" token in the "_prompt_template_" field, however, fmeval/eval_algorithms/__init__.py: **_DEFAULT_PROMPT_TEMPLATE = "$model_input"_**, replaced "$feature" with "$model_input"
3. Fixing exceptions in **_pricing_calculator.py_** caused by missing fields (pricing of output tokens, or int value multiplied by float value)
4. Adding **jupyterlab** to requirements.txt to enable local execution of Jupyter 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
